### PR TITLE
Handle integer overflow by treating number component as string if too large

### DIFF
--- a/test/version_sorter_test.rb
+++ b/test/version_sorter_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'test/unit'
 require 'version_sorter'
 require 'rubygems/version'
@@ -42,5 +43,19 @@ class VersionSorterTest < Test::Unit::TestCase
     randomized = big_numbers.sample(big_numbers.size)
 
     assert_equal big_numbers, VersionSorter.sort(randomized)
+  end
+
+  def test_handles_non_version_data
+    non_versions = [
+      "", " ", ".", "-", "ćevapčići", "The Quick Brown Fox", '!@#$%^&*()',
+      "<--------->", "a12a8a4a22122d01541b62193e9bdad7f5eda552", "1." * 65
+    ]
+    sorted = [
+      "<--------->", "-", "The Quick Brown Fox",
+      "a12a8a4a22122d01541b62193e9bdad7f5eda552", "ćevapčići",
+      "", " ", ".", '!@#$%^&*()', "1." * 65
+    ]
+
+    assert_equal sorted, VersionSorter.sort(non_versions)
   end
 end

--- a/test/version_sorter_test.rb
+++ b/test/version_sorter_test.rb
@@ -30,4 +30,17 @@ class VersionSorterTest < Test::Unit::TestCase
 
     assert_equal sorted_versions, VersionSorter.rsort(versions)
   end
+
+  def test_does_not_raise_on_number_overflow
+    big_numbers = [
+      (2**32).to_s,
+      (2**32 + 1).to_s,
+      (2**32 + 2).to_s,
+      (2**32 - 2).to_s,
+      (2**32 - 1).to_s,
+    ]
+    randomized = big_numbers.sample(big_numbers.size)
+
+    assert_equal big_numbers, VersionSorter.sort(randomized)
+  end
 end


### PR DESCRIPTION
@vmg I want your feedback on this idea that I had, please. Since who knows what kind of data might be fed to VersionSorter, I'd like it to be more forgiving about invalid version numbers rather than raising RuntimeError.

So now if an integer overflow happens when parsing a number component, simply start treating it as a string component at that point. Let me know what you think about the style that I implemented this in.

I've added you as a collab on my fork so you can push your edits here if desired. Thanks